### PR TITLE
fix: use Config.apiBaseUrl & email as userId in HomePage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,13 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+### 패키지 설치
+flutter pub get
+
+### 실행 방법
+모바일(Android/iOS)
+flutter run
+
+웹(Web)
+flutter run -d chrome

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,1 +1,3 @@
-const String apiBaseUrl = 'http://localhost:8080';
+class Config {
+  static const String apiBaseUrl = 'http://localhost:8080';
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,9 @@ import 'pages/onboarding_page.dart';
 import 'pages/signup_page.dart';
 import 'pages/LoginRedirectPage.dart';
 
+import 'package:shared_preferences/shared_preferences.dart';
+import 'config.dart';
+
 void main() {
   runApp(const MyApp());
 }
@@ -53,7 +56,8 @@ class MyApp extends StatelessWidget {
         '/signup': (context) => SignUpPage(),
         '/login-redirect': (context) => const LoginRedirectPage(), // fallback 용도
         '/my': (context) => MyPage(),
-        '/library': (context) => LibraryPage(books: []),
+        // '/library': (context) => LibraryPage(books: []),
+        '/library': (context) => const _LibraryRoute(),
         '/onboarding': (context) => OnboardingPage(),
       },
 
@@ -75,6 +79,45 @@ class MyApp extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+}
+
+/// ✅ LibraryPage로 들어가기 전에 userId/email 과 apiBaseUrl을 준비하는 래퍼
+class _LibraryRoute extends StatefulWidget {
+  const _LibraryRoute({Key? key}) : super(key: key);
+
+  @override
+  State<_LibraryRoute> createState() => _LibraryRouteState();
+}
+
+class _LibraryRouteState extends State<_LibraryRoute> {
+  String? _email;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final email = prefs.getString('email') ?? 'guest';
+    setState(() => _email = email);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_email == null) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    return LibraryPage(
+      books: const [],               // TODO: 서버에서 불러오면 이 자리에서 넣기
+      userId: _email!,
+      apiBaseUrl: Config.apiBaseUrl,
     );
   }
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -27,8 +27,8 @@ class _HomePageState extends State<HomePage> {
     super.initState();
     SharedPreferences.getInstance().then((prefs) {
     print('■ Home initState prefs 토큰: ${prefs.getString('token')}');
-
-    _userId =prefs.getString('userId');
+    // _userId =prefs.getString('userId');
+    _userId =prefs.getString('email');
     setState(() {});
   });
     _fetchMyBooks();
@@ -37,7 +37,7 @@ class _HomePageState extends State<HomePage> {
   Future<void> _fetchMyBooks() async {
     final prefs = await SharedPreferences.getInstance();
     final token = prefs.getString('token');
-    final uri = Uri.parse('http://localhost:8080/api/files/list');
+    final uri = Uri.parse('${Config.apiBaseUrl}/api/files/list');
     final resp = await http.get(
       uri,
       headers: token != null ? {'Authorization': 'Bearer $token'} : {},
@@ -81,7 +81,7 @@ class _HomePageState extends State<HomePage> {
       LibraryPage(
         books: _books,
         userId: _userId ?? '',
-        apiBaseUrl: apiBaseUrl,
+        apiBaseUrl: Config.apiBaseUrl,
       ),
       HomeMainContent(onUpload: _handleNewBook),
       MyPage(),
@@ -303,7 +303,7 @@ class _HomeMainContentState extends State<HomeMainContent> {
     final prefs = await SharedPreferences.getInstance();
     final token = prefs.getString('token');
 
-    final uri = Uri.parse('http://localhost:8080/api/files/analyze-pdf');
+    final uri = Uri.parse('${Config.apiBaseUrl}/api/files/analyze-pdf');
     final req = http.MultipartRequest('POST', uri);
     if (token != null) req.headers['Authorization'] = 'Bearer $token';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -284,10 +284,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -649,10 +649,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
- 홈/라이브러리에 API Base URL을 Config로 통일함
- userId 대신 email을 식별자로 사용함